### PR TITLE
Build fixes for Lua 5.3 and 32-bit

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -512,7 +512,7 @@ void clp_pushchannel(lua_State * L,channel_t t) {
 
 int clp_channelnew(lua_State *L) {
 	channel_t t=malloc(sizeof(struct channel_s));
-	int size=luaL_optint(L, 1, -1);
+	int size=(int)luaL_optinteger(L, 1, -1);
 	int sync=1;
 	if(lua_type(L,2)==LUA_TBOOLEAN) {
 		sync=!lua_toboolean(L, 2);

--- a/src/marshal.c
+++ b/src/marshal.c
@@ -110,8 +110,13 @@ static void mar_encode_value(lua_State *L, mar_Buffer *buf, int val, size_t *idx
 						 if(nowrap) 
 							 luaL_error(L, "light userdata not permitted");
 						 void * ptr_val = lua_touserdata(L, -1);
+						 #if __LP64__ || __LLP64__
 						 long long v = (long long)ptr_val;
 						 buf_write(L, (char*)&v, MAR_I64, buf);
+						 #else
+						 long long v = (long)ptr_val;
+						 buf_write(L, (char*)&v, MAR_I32, buf);
+						 #endif
 						 break;
 					 }
 		case LUA_TTABLE: {
@@ -354,7 +359,11 @@ static void mar_decode_value(lua_State *L, const char *buf, size_t len, const ch
 		case LUA_TLIGHTUSERDATA: {
 						 void * ptr=(void*)*(void**)*p;
 						 lua_pushlightuserdata(L, ptr);
+						 #if __LP64__ || __LLP64__
 						 mar_incr_ptr(MAR_I64);
+						 #else
+						 mar_incr_ptr(MAR_I32);
+						 #endif
 					 } break;
 		case LUA_TSTRING:
 					 mar_next_len(l, uint32_t);

--- a/src/pool.c
+++ b/src/pool.c
@@ -66,7 +66,7 @@ static int pool_ptr(lua_State * L) {
 // @function add
 static int pool_addthread(lua_State * L) {
 	pool_t s=clp_topool(L, 1);
-	int size=luaL_optint(L, 2, 1);
+	int size=(int)luaL_optinteger(L, 2, 1);
 	CHANNEL_LOCK(s);
 	if(size<0) {
 		luaL_error(L,"argument must be positive or zero");

--- a/src/process.c
+++ b/src/process.c
@@ -199,7 +199,7 @@ static int process_tostring (lua_State * L) {
 
 static int process_destroyinstances (lua_State * L) {
 	process_t s = clp_toprocess (L, 1);
-	int n = luaL_optint(L, 2, 0);
+	int n = (int) luaL_optinteger(L, 2, 0);
 	if (n < 0)
 		luaL_error (L, "Argument must be positive");
 	if (n == 0) {
@@ -433,9 +433,9 @@ static int clp_newprocess (lua_State * L) {
 	else {
 		luaL_checktype (L, 1, LUA_TFUNCTION);
 		if(lua_type(L,2) == LUA_TNUMBER) { 
-			idle = luaL_optint (L, 2, 1);
+			idle = (int) luaL_optinteger (L, 2, 1);
 		} else if(lua_type(L,3) == LUA_TNUMBER) {
-			idle = luaL_optint (L, 3, 1);
+			idle = (int) luaL_optinteger (L, 3, 1);
 		} else {
 			idle=1;
 		}


### PR DESCRIPTION
A pair of commits enabling compilation on Lua 5.3 and 32-bit platforms.

This is just a start, as the port is not finished, though: I got errors when trying to run the `tutorial/` examples on Lua 5.3.

For example, lua 01-process.lua returned this:

```
direct  1
direct  2
direct  3
direct  4
nil 1
nil 2
nil 3
nil 4
Process error: 01-process.lua:25: attempt to call a table value (upvalue 'f')
```

Examples 02, 03, 08 and 09 failed with:

```
PANIC: unprotected error in call to Lua API (attempt to call a nil value)
```

Compiling on Lua 5.2, all examples in `tutorial/` ran apparently correctly...

So, now I don't know if the problems are related to Lua 5.3 or to running in 32-bits.
