### PR TITLE
Add a rockspec (plus some Makefile improvements)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 LUA_VER=5.1
 
-LUA_LIBDIR=/usr/local/lib/lua/$(LUA_VER)
-LUA_SHAREDIR=/usr/local/share/lua/$(LUA_VER)
+PREFIX=/usr/local
+
+INSTALL_LIBDIR=$(PREFIX)/lib/lua/$(LUA_VER)
+INSTALL_SHAREDIR=$(PREFIX)/share/lua/$(LUA_VER)
 
 SRC_DIR=src/
 MODULE=clp
@@ -12,19 +14,21 @@ all:
 	cd $(SRC_DIR) && make LUA_VER=$(LUA_VER) all 
 
 install: all
-	mkdir -p $(LUA_LIBDIR)
-	install $(SRC_DIR)/$(BIN) $(LUA_LIBDIR)
+	mkdir -p $(INSTALL_LIBDIR)
+	install $(SRC_DIR)/$(BIN) $(INSTALL_LIBDIR)
 
 install-both: clean
 	cd $(SRC_DIR) && make LUA_VER=5.1 all && cd - && make LUA_VER=5.1 install
 	make clean
 	cd $(SRC_DIR) && make LUA_VER=5.2 all && cd - && make LUA_VER=5.2 install
+	make clean
+	cd $(SRC_DIR) && make LUA_VER=5.3 all && cd - && make LUA_VER=5.3 install
 
 uninstall:
-	rm -f $(LUA_LIBDIR)/$(BIN)
+	rm -f $(INSTALL_LIBDIR)/$(BIN)
 	
 uninstall-both:
-	make LUA_VER=5.1 uninstall && make LUA_VER=5.2 uninstall
+	make LUA_VER=5.1 uninstall && make LUA_VER=5.2 uninstall && make LUA_VER=5.3 uninstall
 
 %:
 	cd $(SRC_DIR) && make $@
@@ -46,6 +50,6 @@ else
 endif
 
 install-mod: 
-	mkdir -p $(LUA_SHAREDIR)/clp/
-	cp -r clp $(LUA_SHAREDIR)/clp/
+	mkdir -p $(INSTALL_SHAREDIR)/clp/
+	cp -r clp $(INSTALL_SHAREDIR)/clp/
 	

--- a/rockspec/clp-scm-1.rockspec
+++ b/rockspec/clp-scm-1.rockspec
@@ -1,0 +1,43 @@
+package = "clp"
+version = "scm-1"
+source = {
+   url = "git://github.com/salmito/clp",
+}
+description = {
+   summary = "Communicating Lua Processes",
+   detailed = [[
+      CLP is a Lua library for bulding lightweight parallel processes based on
+      the concepts of CSP (Communicating Sequential Processes).
+   ]],
+   homepage = "http://github.com/salmito/clp",
+   license = "MIT/X11"
+}
+dependencies = {
+   "lua >= 5.1, <= 5.3"
+}
+external_dependencies = {
+   LIBTBB = {
+      library = "tbb",
+      header = "tbb/concurrent_queue.h",
+   },
+   LIBEVENT = {
+      library = "event",
+   },
+   platforms = {
+      unix = {
+         PTHREAD = {
+            library = "pthread",
+         }
+      }
+   }
+}
+build = {
+   type = "make",
+   variables = {
+      LIBFLAG = "$(LIBFLAG)",
+      INCDIRFLAGS = "-I$(LIBTBB_INCDIR) -I$(LIBEVENT_INCDIR) -I$(PTHREAD_INCDIR) -I$(LUA_INCDIR)",
+      LIBDIRFLAGS = "-L$(LIBTBB_LIBDIR) -L$(LIBEVENT_LIBDIR) -L$(PTHREAD_LIBDIR) -L$(LUA_LIBDIR)",
+      CFLAGS = "$(CFLAGS)",
+      INSTALL_LIBDIR = "$(LIBDIR)",
+   },   
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,13 +2,16 @@ LUA_VER=5.1
 
 LUA_INCDIR=/usr/include/lua$(LUA_VER)
 
-INCFLAGS=-I$(LUA_INCDIR)
-CFLAGS=-fPIC $(INCFLAGS) -Wall $(EXTRA_FLAGS) -O2
-LIBEV_FLAGS=-levent -levent_pthreads
 #EXTRA_FLAGS=-DDEBUG -ggdb
+INCDIRFLAGS=-I$(LUA_INCDIR)
+CFLAGS=-fPIC -Wall -O2
+MODCFLAGS=$(CFLAGS) $(INCDIRFLAGS) $(EXTRA_FLAGS)
+LIBDIRFLAGS=
+LIBEV_FLAGS=-levent -levent_pthreads
 LIBTBB_FLAGS=-ltbb
 PTHREAD_FLAGS=-lpthread -lrt
-LDFLAGS=$(EXTRA_FLAGS) $(PTHREAD_FLAGS) $(LIBTBB_FLAGS) $(LIBEV_FLAGS)
+LDFLAGS=$(EXTRA_FLAGS) $(LIBDIRFLAGS) $(PTHREAD_FLAGS) $(LIBTBB_FLAGS) $(LIBEV_FLAGS)
+LIBFLAG=-shared
 
 LUA=lua
 
@@ -34,16 +37,16 @@ MODULE=clp$(_SO)
 all: $(MODULE)
 
 %.o: %.c $(HEADERS) Makefile
-	$(CC) -c -o $@ $< $(CFLAGS)
+	$(CC) -c -o $@ $< $(MODCFLAGS)
 
 p_queue.o: p_queue.cpp
-	$(G_PLUS_PLUS) -c -o $@ $< $(CFLAGS)
+	$(G_PLUS_PLUS) -c -o $@ $< $(MODCFLAGS)
 
 lf_queue.o: lf_queue.cpp
-	$(G_PLUS_PLUS) -c -o $@ $< $(CFLAGS)
+	$(G_PLUS_PLUS) -c -o $@ $< $(MODCFLAGS)
 	
 $(MODULE): $(OBJ)
-	$(G_PLUS_PLUS) -shared $^ -o $@ $(LDFLAGS)
+	$(G_PLUS_PLUS) $(LIBFLAG) $^ -o $@ $(LDFLAGS)
 
 clean:
 	rm -f *.o


### PR DESCRIPTION
Here's a rockspec plus some minor Makefile improvements, making it easy to set path variables separately from the other compilation and linkage flags, and also letting the user pass their own extra CFLAGS through the usual variable.

This rockspec installs the core `clp.so` module only.
